### PR TITLE
Added exit status and fix issue with some commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'dotrun'
-version = '2.0.1'
+version = '2.0.2'
 description = 'A tool for developing Node.js and Python projects'
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'


### PR DESCRIPTION
This PR fixes https://github.com/canonical/dotrun/issues/99 and fixes https://github.com/canonical/dotrun/issues/98

# QA

Install this version with:
```
sudo pip3 install --upgrade git+https://github.com/canonical/dotrun.git@v2.0.2#egg=dotrun==2.0.2
```

Check that running this command works as expected:
```
dotrun exec yarn add @canonical/react-components --dev
```

Check that you get the correct status code after running a command with dotrun. e.g.: `dotrun exec cp` will fail, so `
echo $?` should return `1`, and something that works like `dotrun exec ls` should return `0`, same for the scripts in the package.json (`build`, `test`, etc...)
