### PR TITLE
WD-4867 - Fix dotrun on codespaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dotrun = "dotrun:cli"
 python = '^3.6'
 python-dotenv = '0.20.0'
 python-slugify = '6.1.2'
-docker = '5.0.3'
+docker = '6.1.3'
 dockerpty = '0.4.1'
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'dotrun'
-version = '2.1.0'
+version = '2.1.1'
 description = 'A tool for developing Node.js and Python projects'
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'


### PR DESCRIPTION
## Done

Bumped the version of docker to the [latest version](https://pypi.org/project/docker/) 6.1.3
Bumped the dotrun version to 2.1.1

## QA

1. Create a codespace on a project such as [vanilla-framework](https://github.com/canonical/vanilla-framework)
2. In the terminal in the codespace. Run `sudo apt install python3-pip`
3. Then run `pip install git+https://github.com/anthonydillon/dotrun.git@test-chunked`
4. Then run `dotrun` and see the site spins up and you can view it from the pop-up URL

Fixes https://github.com/canonical/dotrun/issues/117
