### PR TITLE
Enable dotrun to work within WSL

### DIFF
--- a/dotrun.py
+++ b/dotrun.py
@@ -25,7 +25,10 @@ class Dotrun:
         self.container_home = "/home/ubuntu/"
         self.container_path = f"{self.container_home}{self.project_name}"
         # --network host is only supported on Linux
-        self.network_host_mode = sys.platform.startswith("linux") and "microsoft" not in platform.platform()
+        self.network_host_mode = (
+            sys.platform.startswith("linux")
+            and "microsoft" not in platform.platform()
+        )
         self._get_docker_client()
         self._check_image_updates()
         self._create_cache_volume()

--- a/dotrun.py
+++ b/dotrun.py
@@ -1,8 +1,9 @@
 #! /usr/bin/env python3
 
 import os
-import sys
+import platform
 import re
+import sys
 import time
 import threading
 from importlib import metadata
@@ -24,7 +25,7 @@ class Dotrun:
         self.container_home = "/home/ubuntu/"
         self.container_path = f"{self.container_home}{self.project_name}"
         # --network host is only supported on Linux
-        self.network_host_mode = sys.platform.startswith("linux")
+        self.network_host_mode = sys.platform.startswith("linux") and "microsoft" not in platform.platform()
         self._get_docker_client()
         self._check_image_updates()
         self._create_cache_volume()


### PR DESCRIPTION
This change enables dotrun to work within WSL2.

## Done
Added a platform check for "microsoft". This prevents the port being overwritten to None later in dotrun if `self.network_host_mode` is true. For port forwarding to work otb between a Windows host and wsl2 distro, the port needs to be explicitly set.

## QA
Using the recommended set-up of: WSL2, Ubuntu 22.04 and Docker Desktop for Windows:
- Pull one of our web projects
- Install this version of dotrun: `pip install git+https://github.com/canonical/dotrun.git@enable-dotrun-for-wsl`
- Run `dotrun` – you should be prompted by Windows regarding network access
- When running visit localhost:{port} – everything should work as if local.
