### PR TITLE
add installation script using `pipx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,39 +37,52 @@ $ dotrun --image {image-name} # Use a specific image for dotrun. Useful for runn
 
 ## Installation
 
-### Docker
-
-First, install [Docker](https://docs.docker.com/get-docker/). On Linux, you can install [Docker snap](https://snapcraft.io/docker) instead.
-
-Linux users may also need to follow the [post install instructions](https://docs.docker.com/engine/install/linux-postinstall/) to be able to run Docker as a non-root user.
-
-### Linux
-
-To install dotrun run:
-
-```
-sudo apt install python3-pip
-sudo pip3 install dotrun
-```
-
-### Mac
-
-To install dotrun on a mac you will need [Homebrew](https://brew.sh/) (follow
-the install
-instructions on that page).
-
-Then run:
-
-```
-brew install python3
-sudo pip3 install dotrun
-```
-
 ### Requirements
 
-- Linux / macOS
-- Docker ([Get Docker](https://docs.docker.com/get-docker/))
-- Python > 3.6 and PIP
+- Docker ([Get Docker](https://docs.docker.com/get-docker/)): on Linux, you can install the [Docker snap](https://snapcraft.io/docker) instead.
+- Python 3.10 or later
+- On MacOS: [Homebrew](https://docs.brew.sh/Installation) is required
+- `curl` command-line tool (usually pre-installed on macOS and most Linux distributions)
+
+### Linux and MacOS
+
+#### Quick installation
+
+To install dotrun simply run:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/canonical/dotrun/main/scripts/install.sh | bash
+```
+
+### Verifying the Installation
+
+After installation, you can verify that `dotrun` is installed correctly by running:
+
+```bash
+dotrun version
+```
+
+### Manual Installation
+
+If you prefer to install manually or encounter any issues with the installation script, you can install `dotrun` using the following steps:
+
+1. Install `pipx` if you haven't already:
+
+   * On macOS: `brew install pipx`
+   * On Linux: Follow the installation instructions for your distribution from the [pipx documentation](https://pypa.github.io/pipx/installation/)
+2. Ensure `pipx` is in your PATH:
+
+```bash
+pipx ensurepath
+```
+
+1. Install `dotrun` using `pipx`:
+
+```bash
+pipx install dotrun
+```
+
+If you experience problems, please open a GitHub issue.
 
 ### macOS performance
 
@@ -116,28 +129,34 @@ docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --
 You can install the package locally using either pip or poetry.
 
 ### Using pip
+
 ```bash
 pip3 install . requests==2.31.0
 ```
 
 ### Using Poetry
+
 ```bash
 pip install poetry
 poetry install --no-interaction
 ```
 
 To run dotrun off alternative base images such as local images, you can use the `--image` flag.
+
 ```bash
 dotrun --image "localimage" exec echo hello
 ```
 
 To run dotrun off alternative releases, besides the `:latest` release, you can use the `--release` flag.
+
 ```bash
 dotrun --release "latest" serve
 ```
 
-Note that before changing the base image you should run 
+Note that before changing the base image you should run
+
 ```bash
 dotrun clean
 ```
+
 to get rid of the old virtualenv.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -e
+
+install_pipx_macos() {
+    if command -v brew >/dev/null 2>&1; then
+        echo "Installing pipx using Homebrew..."
+        brew install pipx
+    else
+        echo "Error: Homebrew is not installed on your system."
+        echo "Please install Homebrew first: https://brew.sh/"
+        echo "Then run this script again."
+        exit 1
+    fi
+}
+notice_shown=false
+
+sudo_notice() {
+    if $notice_shown; then
+        return
+    fi
+    echo "-------------------------------------"
+    echo "This step requires sudo privileges to install system packages."
+    echo "You may be prompted to enter your password."
+    echo "-------------------------------------"
+    notice_shown=true
+}
+try_sudo() {
+    # if sudo not installed
+    if ! command -v sudo >/dev/null 2>&1; then
+        "$@"
+    elif [ -z "${SUDO_USER-}" ]; then
+        sudo_notice
+        sudo "$@"
+    else
+        "$@"
+    fi
+}
+
+install_pipx_linux() {
+    if command -v apt-get >/dev/null 2>&1; then
+        echo "Installing pipx using apt..."
+        sudo_notice
+        try_sudo apt update
+        try_sudo apt install -y pipx
+    elif command -v dnf >/dev/null 2>&1; then
+        echo "Installing pipx using dnf..."
+        sudo_notice
+        try_sudo dnf install -y pipx
+    elif command -v pacman >/dev/null 2>&1; then
+        echo "Installing pipx using pacman..."
+        sudo_notice
+        try_sudo pacman -Sy --noconfirm python-pipx
+    else
+        echo "Error: Your linux distribution is not supported by this script."
+        echo "Please follow the manual installation instructions: https://github.com/canonical/dotrun?tab=readme-ov-file#installation"
+        exit 1
+    fi
+}
+
+# Detect the operating system
+# macOS
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    install_pipx_macos
+# Linux
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    install_pipx_linux
+else
+    echo "Unsupported operating system: $OSTYPE"
+    echo "Please follow the manual installation instructions: https://github.com/canonical/dotrun?tab=readme-ov-file#installation"
+    exit 1
+fi
+
+# Install dotrun using pipx
+echo "Installing dotrun..."
+pipx install dotrun
+
+echo "Installation complete!"
+pipx ensurepath


### PR DESCRIPTION
## Done

- Add a quick install script `scripts/install.sh`, this will:
  - Install `pipx`
  - Add `pipx` bin folder to PATH
  - Install `dotrun` using `pipx`
- Update the docs to include the `install.sh` script
- Refactor other parts of the `installation` section

## QA

- Checkout this branch
- Make sure the that script works on:
   - Ubuntu:
    ```bash
    docker run -ti ubuntu bash
    # install prerequisite
    apt update && apt install -y curl
    curl -O https://raw.githubusercontent.com/canonical/dotrun/9cb7a7d/scripts/install.sh 
    bash install.sh
    # reload shell
    su
    # check installation
    dotrun version
    ```
   - Fedora
    ```bash
    docker run -ti fedora bash
    curl -sSL https://raw.githubusercontent.com/canonical/dotrun/9cb7a7d/scripts/install.sh | bash
    # reload shell
    sudo -s
    # check installation
    dotrun version
    ```
   - Arch Linux
    ```bash
    docker run -ti archlinux bash
    curl -sSL https://raw.githubusercontent.com/canonical/dotrun/9cb7a7d/scripts/install.sh | bash
    # reload shell
    su
    # check installation
    dotrun version
    ```