### PR TITLE
add support for custom python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ dotrun serve -m "/path/to/mount":"localname" # Mount additional directory and 
 $ dotrun refresh image # Download the latest version of dotrun-image
 $ dotrun --release {release-version} # Use a specific image tag for dotrun. Useful for switching versions
 $ dotrun --image {image-name} # Use a specific image for dotrun. Useful for running dotrun off local images
+$ dotrun use python 3.8 && dotrun clean && dotrun install # Use a specific python version for dotrun.
 ```
 
 - Note that the `--image` and `--release` arguments cannot be used together, as `--image` will take precedence over `--release`
@@ -68,8 +69,9 @@ If you prefer to install manually or encounter any issues with the installation 
 
 1. Install `pipx` if you haven't already:
 
-   * On macOS: `brew install pipx`
-   * On Linux: Follow the installation instructions for your distribution from the [pipx documentation](https://pypa.github.io/pipx/installation/)
+   - On macOS: `brew install pipx`
+   - On Linux: Follow the installation instructions for your distribution from the [pipx documentation](https://pypa.github.io/pipx/installation/)
+
 2. Ensure `pipx` is in your PATH:
 
 ```bash

--- a/dotrun.py
+++ b/dotrun.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-
+import json
 import os
 import platform
 import re
@@ -97,6 +97,19 @@ class Dotrun:
                 mounts=self._prepare_mounts([]),
                 remove=True,
             )
+
+    def _set_dotrun_state(self, key, value):
+        """
+        Set a project preference
+        """
+        if os.path.exists(".dotrun.json"):
+            with open(".dotrun.json", "r") as f:
+                state = json.load(f)
+        else:
+            state = {}
+        state[key] = value
+        with open(".dotrun.json", "w") as f:
+            json.dump(state, f)
 
     def _prepare_mounts(self, command):
         mounts = [
@@ -300,6 +313,14 @@ def cli():
         dotrun._pull_image()
         print("Latest image pulled successfully.")
         sys.exit(1)
+
+    if len(command) > 1 and command[1] == "use":
+        if len(command) < 4:
+            print("Usage: dotrun use <python|node> <version>")
+            sys.exit(1)
+        dotrun._set_dotrun_state(f"{command[2]}_version", command[3])
+        print(f"Using {command[2]} version {command[3]}")
+        sys.exit(0)
 
     # Options for starting the container using different base images
     if result := _handle_image_cli_param(dotrun, command):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'dotrun'
-version = '2.4.1'
+version = '2.5.0'
 description = 'A tool for developing Node.js and Python projects'
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'


### PR DESCRIPTION
## Done

- Add support for custom python version

## QA

- Run `poetry install --no-interaction`
- Run `DOTRUN_PATH="$(pwd)/.venv/bin/dotrun"`
- Go to any web project
- Run: `$DOTRUN_PATH use python 3.12`
- Make sure that `.dotrun.json` has a new key/value: `"python_version": 3.12`

## Issues

Fixes WD-14227